### PR TITLE
fix issue with reading strict ooxml comments

### DIFF
--- a/src/main/java/com/github/pjfanning/poi/xssf/streaming/TempFileCommentsTable.java
+++ b/src/main/java/com/github/pjfanning/poi/xssf/streaming/TempFileCommentsTable.java
@@ -17,6 +17,8 @@ import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTCommentList;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CommentsDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -38,6 +40,8 @@ import static org.apache.poi.xssf.usermodel.XSSFRelation.NS_SPREADSHEETML;
  * </p>
  */
 public class TempFileCommentsTable extends POIXMLDocumentPart implements Comments, AutoCloseable {
+    private static Logger log = LoggerFactory.getLogger(TempFileCommentsTable.class);
+
     private File tempFile;
     private MVStore mvStore;
 
@@ -257,7 +261,8 @@ public class TempFileCommentsTable extends POIXMLDocumentPart implements Comment
                     richTextString = new XSSFRichTextString(comments.getCommentArray(0).getText());
                     break;
                 default:
-                    throw new IllegalArgumentException("Unexpected element name " + xmlEvent.asStartElement().getName().getLocalPart());
+                    log.debug("ignoring data inside element {}", startElement.getName());
+                    break;
             }
         }
         return richTextString;
@@ -271,12 +276,14 @@ public class TempFileCommentsTable extends POIXMLDocumentPart implements Comment
         XMLEvent xmlEvent;
         String text = null;
         while((xmlEvent = xmlEventReader.nextTag()).isStartElement()) {
-            switch(xmlEvent.asStartElement().getName().getLocalPart()) {
+            StartElement startElement = xmlEvent.asStartElement();
+            switch(startElement.getName().getLocalPart()) {
                 case "text":
                     text = TextParser.parseCT_Rst(xmlEventReader);
                     break;
                 default:
-                    throw new IllegalArgumentException("Unexpected element name " + xmlEvent.asStartElement().getName().getLocalPart());
+                    log.debug("ignoring data inside element {}", startElement.getName());
+                    break;
             }
         }
         return text;

--- a/src/main/java/com/github/pjfanning/poi/xssf/streaming/TempFileSharedStringsTable.java
+++ b/src/main/java/com/github/pjfanning/poi/xssf/streaming/TempFileSharedStringsTable.java
@@ -52,9 +52,9 @@ import static org.apache.poi.xssf.usermodel.XSSFRelation.NS_SPREADSHEETML;
  * </p>
  */
 public class TempFileSharedStringsTable extends SharedStringsTable {
-    private static Logger log = LoggerFactory.getLogger(TempFileSharedStringsTable.class);
-    private static QName COUNT_QNAME = new QName("count");
-    private static QName UNIQUE_COUNT_QNAME = new QName("uniqueCount");
+    private static final Logger log = LoggerFactory.getLogger(TempFileSharedStringsTable.class);
+    private static final QName COUNT_QNAME = new QName("count");
+    private static final QName UNIQUE_COUNT_QNAME = new QName("uniqueCount");
     private File tempFile;
     private MVStore mvStore;
     private final boolean fullFormat;

--- a/src/test/java/com/github/pjfanning/poi/xssf/streaming/TestTempFileCommentsTable.java
+++ b/src/test/java/com/github/pjfanning/poi/xssf/streaming/TestTempFileCommentsTable.java
@@ -11,8 +11,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 public class TestTempFileCommentsTable {
 
@@ -58,6 +57,33 @@ public class TestTempFileCommentsTable {
     @Test
     public void testWriteWithFullFormat() throws Exception {
         testWrite(false, true);
+    }
+
+    @Test
+    public void testReadStrictXML() throws Exception {
+        try (
+                InputStream is = TestTempFileCommentsTable.class.getClassLoader().getResourceAsStream("strict-comments1.xml");
+                TempFileCommentsTable ct = new TempFileCommentsTable(false, false)
+        ) {
+            ct.readFrom(is);
+            assertEquals(1, ct.getNumberOfComments());
+            List<CellAddress> addresses = IteratorUtils.toList(ct.getCellAddresses());
+            assertEquals(1, addresses.size());
+            assertEquals("B1", addresses.get(0).formatAsString());
+            for (CellAddress address : addresses) {
+                Assert.assertNotNull(ct.findCellComment(address));
+            }
+
+            assertEquals(1, ct.getNumberOfAuthors());
+            assertEquals("tc={12222C35-D781-4D4A-81D9-2C6FD97BD160}", ct.getAuthor(0));
+            assertEquals(1, ct.findAuthor("new-author"));
+            assertEquals("new-author", ct.getAuthor(1));
+
+            XSSFRichTextString testComment = ct.findCellComment(addresses.get(0)).getString();
+            assertTrue("comment text contains expected value?",
+                    testComment.getString().contains("Gaeilge"));
+            assertEquals(0, testComment.numFormattingRuns());
+        }
     }
 
     private void testReadXML(boolean encrypt, boolean fullFormat) throws Exception {

--- a/src/test/resources/strict-comments1.xml
+++ b/src/test/resources/strict-comments1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<comments xmlns="http://purl.oclc.org/ooxml/spreadsheetml/main" xmlns:xdr="http://purl.oclc.org/ooxml/drawingml/spreadsheetDrawing" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="xr" xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision"><authors><author>tc={12222C35-D781-4D4A-81D9-2C6FD97BD160}</author></authors><commentList><comment ref="B1" authorId="0" shapeId="1025" xr:uid="{12222C35-D781-4D4A-81D9-2C6FD97BD160}"><text><t>[Threaded comment]
+
+    Your version of Excel allows you to read this threaded comment; however, any edits to it will get removed if the file is opened in a newer version of Excel. Learn more: https://go.microsoft.com/fwlink/?linkid=870924
+
+    Comment:
+    Gaeilge</t></text><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"><mc:Choice Requires="v"/><mc:Fallback><commentPr defaultSize="0" autoFill="0" autoLine="0"><anchor><from><xdr:col>2</xdr:col><xdr:colOff>137160</xdr:colOff><xdr:row>0</xdr:row><xdr:rowOff>15240</xdr:rowOff></from><to><xdr:col>4</xdr:col><xdr:colOff>289560</xdr:colOff><xdr:row>4</xdr:row><xdr:rowOff>7620</xdr:rowOff></to></anchor></commentPr></mc:Fallback></mc:AlternateContent></comment></commentList></comments>


### PR DESCRIPTION
* so far, 'full format' parsing is not supported for OOXML strict format comments files - this relies on XMLBeans parsing that only supports the namespaces in OOXML transitional format (the usual format) 