### PR TITLE
Fix exception when shared-strings file contains phonetic hints

### DIFF
--- a/src/main/java/com/github/pjfanning/poi/xssf/streaming/TextParser.java
+++ b/src/main/java/com/github/pjfanning/poi/xssf/streaming/TextParser.java
@@ -118,7 +118,7 @@ class TextParser {
 
     private static void skipElement(XMLEventReader xmlEventReader) throws XMLStreamException {
         // Precondition: pointing to start element;  Post condition: pointing to end element
-        while(xmlEventReader.nextTag().isStartElement()) {
+        while(xmlEventReader.nextEvent().isStartElement()) {
             skipElement(xmlEventReader); // recursively skip over child
         }
     }

--- a/src/test/java/com/github/pjfanning/poi/xssf/streaming/TestTempFileSharedStringsTable.java
+++ b/src/test/java/com/github/pjfanning/poi/xssf/streaming/TestTempFileSharedStringsTable.java
@@ -48,6 +48,22 @@ public class TestTempFileSharedStringsTable {
     }
 
     @Test
+    public void testReadXMLWithPhoneticHints() throws Exception {
+        try (InputStream is = TestTempFileSharedStringsTable.class.getClassLoader().getResourceAsStream("sharedStrings-with-phonetic-hints.xml");
+             TempFileSharedStringsTable sst = new TempFileSharedStringsTable(false, false)) {
+            sst.readFrom(is);
+            assertEquals(3, sst.getUniqueCount());
+            assertEquals(3, sst.getCount());
+            assertEquals("Country", sst.getItemAt(0).getString());
+            assertEquals("Country", sst.getString(0));
+            assertEquals("City", sst.getItemAt(1).getString());
+            assertEquals("City", sst.getString(1));
+            assertEquals("沖縄", sst.getItemAt(2).getString());
+            assertEquals("沖縄", sst.getString(2));
+        }
+    }
+
+    @Test
     public void testReadStyledXML() throws Exception {
         testReadStyledXML(false);
     }

--- a/src/test/resources/sharedStrings-with-phonetic-hints.xml
+++ b/src/test/resources/sharedStrings-with-phonetic-hints.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="3" uniqueCount="3"><si><t>Country</t></si><si><t>City</t><phoneticPr fontId="1"/></si><si><t>沖縄</t><rPh sb="0" eb="2"><t>オキナワ</t></rPh><phoneticPr fontId="1"/></si></sst>


### PR DESCRIPTION
When, I read file with phonetic hints ('phonetic properties' `phoneticPr` and 'phonetic run' `rPh` XML tag inside the file `sharedStrings.xml`) I have an exception : 
```
Caused by: javax.xml.stream.XMLStreamException: ParseError at [row,col]:[2,113]
Message: found: CHARACTERS, expected START_ELEMENT or END_ELEMENT
	at java.xml@15.0.6/com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.nextTag(XMLStreamReaderImpl.java:1361)
	at java.xml@15.0.6/com.sun.xml.internal.stream.XMLEventReaderImpl.nextTag(XMLEventReaderImpl.java:242)
	at app//com.github.pjfanning.poi.xssf.streaming.TextParser.skipElement(TextParser.java:121)
	at app//com.github.pjfanning.poi.xssf.streaming.TextParser.skipElement(TextParser.java:122)
	at app//com.github.pjfanning.poi.xssf.streaming.TextParser.parseCT_Rst(TextParser.java:43)
	at app//com.github.pjfanning.poi.xssf.streaming.SharedStringsTableBase.readFrom(SharedStringsTableBase.java:136)
```


 